### PR TITLE
Improve German date format

### DIFF
--- a/index-de-DE.html
+++ b/index-de-DE.html
@@ -14,7 +14,7 @@ root: true
 </p>
 
 <p>
-  Zuletzt aktualisiert am {{ "2024/07/02" | date: "%d.%m" }}: Selbstständig. Schläft, strickt, spielt Squash, macht Yoga, lernt Deutsch und backt manchmal Brot. Berührt selten einen Laptop. Plant teilzeit in Berlin zu leben.
+  Zuletzt aktualisiert am {{ "2024/07/02" | date: "%d.&thinsp;%m." }}: Selbstständig. Schläft, strickt, spielt Squash, macht Yoga, lernt Deutsch und backt manchmal Brot. Berührt selten einen Laptop. Plant teilzeit in Berlin zu leben.
 </p>
 
 <nav aria-label="Extra Inhalt">


### PR DESCRIPTION
Didn't have a ruby thing running so I couldn't verify the `&thinsp;` isn't escaped here :/